### PR TITLE
Nitrozen Dropdown Standarization

### DIFF
--- a/src/components/NDropdown/NDropdown.less
+++ b/src/components/NDropdown/NDropdown.less
@@ -140,11 +140,11 @@
   }
   // Disabled
   .nitrozen-select.disabled {
-    background-color: @BorderColor;
+    background-color: #EDEDED;
   }
   .nitrozen-select.disabled .nitrozen-select__trigger {
-    color: @DisabledColor;
-    background-color: @BorderColor;
+    background-color: #EDEDED;
+    color: #9C9CAA;
     cursor: not-allowed;
   }
   .nitrozen-select.disabled .nitrozen-select__trigger .nitrozen-dropdown-arrow {

--- a/src/components/NDropdown/NDropdown.vue
+++ b/src/components/NDropdown/NDropdown.vue
@@ -131,7 +131,7 @@
             </slot>
           </span>
           <span v-if="searchable && items.length == 0" class="nitrozen-option">
-            <div class="nitrozen-option-container" v-if="!add_option">No {{ label }} Found</div>
+            <div class="nitrozen-option-container" v-if="!add_option">No {{ optionLabel }} found</div>
             <div class="nitrozen-option-container" v-else-if="add_option && searchInput.length">
               <div class="nitrozen-dropdown-empty"
                 @click="addOption"
@@ -194,6 +194,10 @@ export default {
      */
     label: {
       type: String,
+    },
+    optionLabel: {
+      type: String,
+      default: 'option'
     },
     /**
      * multiselect value
@@ -282,7 +286,7 @@ export default {
         if (this.selected && this.selected.text) {
           return this.selected.text;
         } else if (this.label) {
-          return this.placeholder || `Choose ${this.label}`;
+          return this.placeholder || `Select ${this.label}`;
         }
         return "";
       } else {
@@ -308,7 +312,7 @@ export default {
           tmp = [...new Set(tmp)];
           return `${tmp.join(", ")}`;
         } else if (this.label) {
-          return this.placeholder || `Choose ${this.label}`;
+          return this.placeholder || `Select ${this.label}`;
         }
         return "";
       }

--- a/src/components/NDropdown/NDropdown.vue
+++ b/src/components/NDropdown/NDropdown.vue
@@ -131,7 +131,7 @@
             </slot>
           </span>
           <span v-if="searchable && items.length == 0" class="nitrozen-option">
-            <div class="nitrozen-option-container" v-if="!add_option">No {{ optionLabel }} found</div>
+            <div class="nitrozen-option-container" v-if="!add_option">{{this.noresults_text}}</div>
             <div class="nitrozen-option-container" v-else-if="add_option && searchInput.length">
               <div class="nitrozen-dropdown-empty"
                 @click="addOption"
@@ -241,6 +241,14 @@ export default {
     enable_select_all: {
       type: Boolean,
       default: false
+    },
+    noresults_text: {
+      type: String,
+      default: "No options found"
+    },
+    allseleceted_text: {
+      type: String,
+      default: ""
     }
   },
   data: () => {
@@ -291,7 +299,7 @@ export default {
         return "";
       } else {
         if (this.allOptionsSelected) {
-          return `All ${this.selectedItems.length} ${this.label} selected`
+          return `All ${this.selectedItems.length} selected`;
         }
         let tmp = [];
         let selected = {};
@@ -320,7 +328,7 @@ export default {
     searchInputPlaceholder: function() {
       if (this.enable_select_all && this.selectedItems.length) {
         if(this.selectedItems.length === this.getItems(this.items).length) {
-          return `All ${this.label}(s) selected`
+          return this.allseleceted_text ? this.allseleceted_text : `All ${this.label}(s) selected`;
         }
         return `${this.selectedItems.length} ${this.label}(s) selected`
       }

--- a/src/components/NDropdown/NDropdown.vue
+++ b/src/components/NDropdown/NDropdown.vue
@@ -195,10 +195,6 @@ export default {
     label: {
       type: String,
     },
-    optionLabel: {
-      type: String,
-      default: 'option'
-    },
     /**
      * multiselect value
      */

--- a/src/components/NDropdown/NDropdown.vue
+++ b/src/components/NDropdown/NDropdown.vue
@@ -131,7 +131,7 @@
             </slot>
           </span>
           <span v-if="searchable && items.length == 0" class="nitrozen-option">
-            <div class="nitrozen-option-container" v-if="!add_option">{{this.noresults_text}}</div>
+            <div class="nitrozen-option-container" v-if="!add_option">{{noresults_text}}</div>
             <div class="nitrozen-option-container" v-else-if="add_option && searchInput.length">
               <div class="nitrozen-dropdown-empty"
                 @click="addOption"


### PR DESCRIPTION
In the nitrozen-dropdown component, when there are no items found, the default message displayed uses the label prop as part of the text. For example, if the label is set to "Select Brand," the message displayed is "No Select Brand Found." This can result in awkward phrasing that might confuse users.

Solution:
To improve clarity and flexibility, we have introduced a new prop called optionLabel. By default, this prop is set to "option," so the message will now be "No option found" unless a custom value is provided. This allows developers to set a more appropriate and user-friendly message based on their specific use case.

Background color change so when the dropdown is disabled the placeholder/data should be visible properly